### PR TITLE
Type with EventMap

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,22 @@
-type Listener<EventArgument> = (...args: EventArgument[]) => void
 type Unlisten = () => void
+type Listener<EventArgument> = (...args: EventArgument[]) => void
 
-export interface Emitter<EventName extends string, EventArgument> {
-	on(event: EventName, listener: Listener<EventArgument>): Unlisten,
-	once(event: EventName, listener: Listener<EventArgument>): Unlisten,
-	emit(event: EventName, ...args: EventArgument[]): void,
-	removeAllListeners(): void,
+interface Listen<EventMap> {
+	<EventName extends keyof EventMap>(eventName: EventName, listener: Listener<EventMap[EventName]>) : Unlisten,
 }
 
-declare function createEmitter<InputObject, EventName extends string, EventArgument>(inputObject: InputObject): Emitter<EventName, EventArgument> & InputObject
-declare function createEmitter<EventName extends string, EventArgument>(): Emitter<EventName, EventArgument>
+interface Emit<EventMap> {
+  <EventName extends keyof EventMap>(eventName: EventName, ...eventArgs: EventMap[EventName][]) : void
+}
+
+export interface Emitter<EventMap> {
+	on: Listen<EventMap>,
+	once: Listen<EventMap>,
+	emit: Emit<EventMap>,
+	removeAllListeners(): void
+}
+
+declare function createEmitter<EventMap>(): Emitter<EventMap>
+declare function createEmitter<EventMap, InputObject>(inputObject): Emitter<EventMap> & InputObject
 
 export default createEmitter

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export interface Emitter<EventName extends string, EventArgument> {
 	removeAllListeners(): void,
 }
 
-declare function makeEmitter<Object, EventName extends string, EventArgument>(object?: Object): Emitter<EventName, EventArgument> & Object
+declare function createEmitter<InputObject, EventName extends string, EventArgument>(inputObject: InputObject): Emitter<EventName, EventArgument> & InputObject
+declare function createEmitter<EventName extends string, EventArgument>(): Emitter<EventName, EventArgument>
 
-export default makeEmitter
+export default createEmitter

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
-type Listener = (...args) => void
+type Listener<EventArgument> = (...args: EventArgument[]) => void
 type Unlisten = () => void
 
-export interface Emitter {
-	on(event: string, listener: Listener): Unlisten,
-	once(event: string, listener: Listener): Unlisten,
-	emit(event: string, ...args): void,
+export interface Emitter<EventName extends string, EventArgument> {
+	on(event: EventName, listener: Listener<EventArgument>): Unlisten,
+	once(event: EventName, listener: Listener<EventArgument>): Unlisten,
+	emit(event: EventName, ...args: EventArgument[]): void,
 	removeAllListeners(): void,
 }
 
-declare function makeEmitter<Object>(object?: Object): Emitter & Object
+declare function makeEmitter<Object, EventName extends string, EventArgument>(object?: Object): Emitter<EventName, EventArgument> & Object
 
 export default makeEmitter

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A very simple event emitter with a better API than all the others",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js && jsmd readme.md && echo \"Readme passed!\""
+		"test-ts": "tsc --noEmit sample.ts && ts-node sample.ts",
+    "test": "node test.js && jsmd readme.md && echo \"Readme passed!\" && npm run test-ts"
   },
   "repository": {
     "type": "git",
@@ -28,7 +29,9 @@
   "homepage": "https://github.com/TehShrike/better-emitter#readme",
   "devDependencies": {
     "jsmd": "0.3.1",
-    "tape": "4.8.0"
+    "tape": "4.8.0",
+    "ts-node": "^7.0.1",
+    "typescript": "^3.1.1"
   },
   "dependencies": {
     "key-master": "4.0.0"

--- a/sample.ts
+++ b/sample.ts
@@ -1,32 +1,9 @@
 import createEmitter from './'
 
-const stringTakingFunction = (...strings: string[]) => {}
+const emitter = createEmitter<{ 'foo': string, 'bar': number }>()
 
-const backwardCompatibleEmitter = createEmitter()
-backwardCompatibleEmitter.on('whatever', () => {})
-backwardCompatibleEmitter.emit('whatever')
+emitter.on('foo', (v: string) => v)
+emitter.emit('foo', 'football')
 
-const anyEmitter = createEmitter<any, any>()
-anyEmitter.on('whatever', stringTakingFunction)
-anyEmitter.emit('whatever', 123)
-
-const ordinaryEmitter = createEmitter<'foo' | 'baz', string>()
-ordinaryEmitter.on('foo', () => {})
-ordinaryEmitter.on('baz', () => {})
-ordinaryEmitter.on('foo', stringTakingFunction)
-ordinaryEmitter.on('baz', stringTakingFunction)
-ordinaryEmitter.emit('foo', 'football')
-ordinaryEmitter.emit('baz', 'bazketball', 'bazillion')
-ordinaryEmitter.removeAllListeners()
-
-interface CoolObject {
-	degrees: number
-}
-
-type AmazingEvent = 'shock' | 'awe' | 'wonder' | 'amazement'
-type AmazingArgument = string | number
-
-const amazingEmitter = createEmitter <CoolObject, AmazingEvent, AmazingArgument> ({ degrees: 60 })
-amazingEmitter.on('wonder', stringTakingFunction)
-amazingEmitter.emit('wonder', 'ful')
-amazingEmitter.removeAllListeners()
+emitter.on('bar', (v: number) => v)
+emitter.emit('bar', 123)

--- a/sample.ts
+++ b/sample.ts
@@ -1,0 +1,30 @@
+import createEmitter, { Emitter } from './'
+
+interface CoolThing {
+	degrees: number
+}
+
+type AmazingEvent = 'shock' | 'awe' | 'wonder' | 'amazement'
+type AmazingArgument = string | number
+type AmazingThing = CoolThing & Emitter<AmazingEvent, AmazingArgument>
+
+const coolThing : CoolThing = {
+	degrees: 60
+}
+
+const ordinaryThing : Emitter<'foo' | 'baz', string> = createEmitter()
+
+const amazingThing : AmazingThing = createEmitter(coolThing)
+
+const stringTakingFunction = (...strings: string[]) => {}
+
+ordinaryThing.emit('foo', 'football')
+ordinaryThing.emit('baz', 'bazketball', 'bazillion')
+ordinaryThing.on('foo', () => {})
+ordinaryThing.on('baz', () => {})
+ordinaryThing.on('foo', stringTakingFunction)
+ordinaryThing.on('baz', stringTakingFunction)
+ordinaryThing.removeAllListeners()
+
+amazingThing.on('wonder', stringTakingFunction)
+amazingThing.removeAllListeners()

--- a/sample.ts
+++ b/sample.ts
@@ -1,30 +1,32 @@
-import createEmitter, { Emitter } from './'
+import createEmitter from './'
 
-interface CoolThing {
+const stringTakingFunction = (...strings: string[]) => {}
+
+const backwardCompatibleEmitter = createEmitter()
+backwardCompatibleEmitter.on('whatever', () => {})
+backwardCompatibleEmitter.emit('whatever')
+
+const anyEmitter = createEmitter<any, any>()
+anyEmitter.on('whatever', stringTakingFunction)
+anyEmitter.emit('whatever', 123)
+
+const ordinaryEmitter = createEmitter<'foo' | 'baz', string>()
+ordinaryEmitter.on('foo', () => {})
+ordinaryEmitter.on('baz', () => {})
+ordinaryEmitter.on('foo', stringTakingFunction)
+ordinaryEmitter.on('baz', stringTakingFunction)
+ordinaryEmitter.emit('foo', 'football')
+ordinaryEmitter.emit('baz', 'bazketball', 'bazillion')
+ordinaryEmitter.removeAllListeners()
+
+interface CoolObject {
 	degrees: number
 }
 
 type AmazingEvent = 'shock' | 'awe' | 'wonder' | 'amazement'
 type AmazingArgument = string | number
-type AmazingThing = CoolThing & Emitter<AmazingEvent, AmazingArgument>
 
-const coolThing : CoolThing = {
-	degrees: 60
-}
-
-const ordinaryThing : Emitter<'foo' | 'baz', string> = createEmitter()
-
-const amazingThing : AmazingThing = createEmitter(coolThing)
-
-const stringTakingFunction = (...strings: string[]) => {}
-
-ordinaryThing.emit('foo', 'football')
-ordinaryThing.emit('baz', 'bazketball', 'bazillion')
-ordinaryThing.on('foo', () => {})
-ordinaryThing.on('baz', () => {})
-ordinaryThing.on('foo', stringTakingFunction)
-ordinaryThing.on('baz', stringTakingFunction)
-ordinaryThing.removeAllListeners()
-
-amazingThing.on('wonder', stringTakingFunction)
-amazingThing.removeAllListeners()
+const amazingEmitter = createEmitter <CoolObject, AmazingEvent, AmazingArgument> ({ degrees: 60 })
+amazingEmitter.on('wonder', stringTakingFunction)
+amazingEmitter.emit('wonder', 'ful')
+amazingEmitter.removeAllListeners()


### PR DESCRIPTION
Here's typing with an EventMap so that specific event names can be associated with specific argument types for `emit` and listeners, as opposed to #5, in which any valid argument type could be used with any valid event name. The ts-node / cjs issue remains unsolved.