### PR TITLE
Add explicit any[] type to emitter args

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ type Unlisten = () => void
 interface Emitter {
 	on(event: string, listener: Listener): Unlisten,
 	once(event: string, listener: Listener): Unlisten,
-	emit(event: string, ...args): void
+	emit(event: string, ...args: any[]): void
 }
 
 declare function makeEmitter<Object>(object?: Object): Emitter & Object


### PR DESCRIPTION
Ensures better-emitter can be compiled when strict mode and/or noImplicitAny mode is enabled.