### PR TITLE
Implement stopPropagation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,5 @@
 const keyMaster = require(`key-master`)
 
-const assertType = (name, value, expectedType) => {
-	const actualType = typeof value
-	if (actualType !== expectedType) {
-		throw new Error(`Expected ${ name } to be ${ expectedType } but it was ${ actualType }`)
-	}
-}
-
 const freshMap = () => keyMaster(() => new Map())
 
 module.exports = function createEmitter(emitter = Object.create(null)) {
@@ -14,9 +7,6 @@ module.exports = function createEmitter(emitter = Object.create(null)) {
 	let nextId = 0
 
 	emitter.on = (event, listener) => {
-		assertType(`event`, event, `string`)
-		assertType(`listener`, listener, `function`)
-
 		const id = (nextId++).toString()
 		const listeners = eventsToListeners.get(event)
 		listeners.set(id, listener)
@@ -31,9 +21,6 @@ module.exports = function createEmitter(emitter = Object.create(null)) {
 	}
 
 	emitter.once = (event, listener) => {
-		assertType(`event`, event, `string`)
-		assertType(`listener`, listener, `function`)
-
 		const unsubscribe = emitter.on(event, (...args) => {
 			listener(...args)
 			unsubscribe()
@@ -43,8 +30,6 @@ module.exports = function createEmitter(emitter = Object.create(null)) {
 	}
 
 	emitter.emit = (event, arg) => {
-		assertType(`event`, event, `string`)
-
 		const listeners = eventsToListeners.get(event)
 		for (const listener of listeners.values()) {
 			listener(arg)

--- a/index.js
+++ b/index.js
@@ -42,12 +42,12 @@ module.exports = function createEmitter(emitter = Object.create(null)) {
 		return unsubscribe
 	}
 
-	emitter.emit = (event, ...args) => {
+	emitter.emit = (event, arg) => {
 		assertType(`event`, event, `string`)
 
 		const listeners = eventsToListeners.get(event)
 		for (const listener of listeners.values()) {
-			listener(...args)
+			listener(arg)
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -31,8 +31,12 @@ module.exports = function createEmitter(emitter = Object.create(null)) {
 
 	emitter.emit = (event, arg) => {
 		const listeners = eventsToListeners.get(event)
+		let stoppedPropagation = false
+		const stopPropagation = () => stoppedPropagation = true
 		for (const listener of listeners.values()) {
-			listener(arg)
+			if (!stoppedPropagation) {
+				listener(arg, { stopPropagation })
+			}
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,532 @@
 {
   "name": "better-emitter",
   "version": "2.3.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "better-emitter",
+      "version": "2.3.0",
+      "license": "WTFPL",
+      "dependencies": {
+        "key-master": "4.0.0"
+      },
+      "devDependencies": {
+        "jsmd": "^1.0.2",
+        "tape": "4.8.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "dependencies": {
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "node_modules/es-abstract": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
+      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+      "dev": true,
+      "dependencies": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true,
+      "dependencies": {
+        "is-function": "~1.0.0"
+      }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "dev": true
+    },
+    "node_modules/is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jsmd": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jsmd/-/jsmd-1.0.2.tgz",
+      "integrity": "sha512-mrQ80ysClsuw4QASa7JcjpwgTADBclo9LgIPDERD99tsfVcXGEHjkX50Q9N0NSmX1Zq3xxQYAA8fuN9GHk1Beg==",
+      "dev": true,
+      "dependencies": {
+        "escodegen": "^1.9.1",
+        "esprima": "^2.7.3",
+        "estraverse": "^4.2.0",
+        "marked": "^0.7.0",
+        "v8-argv": "github:jkroso/v8-argv#1.1.1"
+      },
+      "bin": {
+        "jsmd": "bin/jsmd"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/key-master": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/key-master/-/key-master-4.0.0.tgz",
+      "integrity": "sha512-yEO7Twi4tG9q/Y0WinAiMoeDHIGJTfB8/f8KwVbP9Sz74g+zn4CjIGWl9d3hn7TiLJQR4zd0s83jT/4m20HP3w=="
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "node_modules/object-inspect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
+      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
+      "dev": true
+    },
+    "node_modules/object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "dependencies": {
+        "path-parse": "^1.0.5"
+      }
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/tape": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
+      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.2",
+        "function-bind": "~1.1.0",
+        "glob": "~7.1.2",
+        "has": "~1.0.1",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.3.0",
+        "resolve": "~1.4.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/v8-argv": {
+      "version": "1.1.1",
+      "resolved": "git+ssh://git@github.com/jkroso/v8-argv.git#284f84379e292eb956a5e7b66fb953ec4974385e",
+      "integrity": "sha512-OVTIyre4uhPX2v7QlbgS2R646XUcln4mNOwWhtzixaeGfGl5TChDb2gZ4fRhhN44xY/oSzPb0Vfh0LEVGQrr5A==",
+      "dev": true,
+      "license": "WTFPL"
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  },
   "dependencies": {
     "balanced-match": {
       "version": "1.0.0",
@@ -397,9 +921,9 @@
       }
     },
     "v8-argv": {
-      "version": "github:jkroso/v8-argv#284f84379e292eb956a5e7b66fb953ec4974385e",
-      "from": "github:jkroso/v8-argv#1.1.1",
-      "dev": true
+      "version": "git+ssh://git@github.com/jkroso/v8-argv.git#284f84379e292eb956a5e7b66fb953ec4974385e",
+      "dev": true,
+      "from": "v8-argv@github:jkroso/v8-argv#1.1.1"
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/readme.md
+++ b/readme.md
@@ -25,12 +25,11 @@ const createEmitter = require('./')
 ```js
 const emitter = createEmitter()
 
-const unsubscribe = emitter.on('thing happened', (really, why) => {
+const unsubscribe = emitter.on('thing happened', (really) => {
 	really // => true
-	why // => 'I dunno'
 })
 
-emitter.emit('thing happened', true, 'I dunno')
+emitter.emit('thing happened', true)
 
 unsubscribe()
 ```
@@ -47,9 +46,9 @@ Adds an event listener function.  Returns an unsubscribe function that, when cal
 
 Just like the `on` function, except the listener is automatically unsubscribed after the first time the event is emitted.
 
-## `emitter.emit(eventString, [...args])`
+## `emitter.emit(eventString, [arg])`
 
-Calls all listeners of the given event string, with any arguments.
+Calls all listeners of the given event string, with one optional argument.
 
 ## `emitter.removeAllListeners()`
 

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,9 @@ const createEmitter = require('./')
 ```js
 const emitter = createEmitter()
 
-const unsubscribe = emitter.on('thing happened', (really) => {
+const unsubscribe = emitter.on('thing happened', (really, { stopPropagation }) => {
 	really // => true
+	typeof stopPropagation // => 'function'
 })
 
 emitter.emit('thing happened', true)
@@ -41,6 +42,8 @@ This is the function exported by the module.  It creates a new event emitter obj
 ## `unsubscribe = emitter.on(eventString, listenerFunction)`
 
 Adds an event listener function.  Returns an unsubscribe function that, when called, prevents the listener from firing any more.
+
+The listener function will be passed the optional argument that you passed into `emit`, as well as an object with a `stopPropagation` function that you can call to prevent any other listeners from getting the message.
 
 ## `unsubscribe = emitter.once(eventString, listenerFunction)`
 

--- a/test.js
+++ b/test.js
@@ -127,3 +127,19 @@ test(`removeAllListeners`, t => {
 
 	t.end()
 })
+
+test(`stopPropagation`, t => {
+	const emitter = createEmitter()
+
+	emitter.on(`wat`, (_, { stopPropagation }) => {
+		stopPropagation()
+	})
+
+	emitter.on(`wat`, () => {
+		t.fail(`Should not be called because the first listener called stopPropagation`)
+	})
+
+	emitter.emit(`wat`)
+
+	t.end()
+})

--- a/test.js
+++ b/test.js
@@ -109,20 +109,6 @@ test(`Events work when you pass in your own object`, t => {
 	t.end()
 })
 
-test(`Types`, t => {
-	const emitter = createEmitter()
-
-	t.throws(() => emitter.on(), /string/)
-	t.throws(() => emitter.on(`wat`), /function/)
-
-	t.throws(() => emitter.once(), /string/)
-	t.throws(() => emitter.once(`wat`), /function/)
-
-	t.throws(() => emitter.emit(), /string/)
-
-	t.end()
-})
-
 test(`removeAllListeners`, t => {
 	const emitter = createEmitter()
 

--- a/test.js
+++ b/test.js
@@ -7,19 +7,17 @@ test(`Events work (in order)`, t => {
 	let firstFired = false
 
 	emitter.on(`Shouldn't happen`, () => t.fail())
-	emitter.on(`wat`, (a, b) => {
+	emitter.on(`wat`, a => {
 		t.equal(a, `arg1`)
-		t.equal(b, `arg2`)
 		firstFired = true
 	})
-	emitter.on(`wat`, (a, b) => {
+	emitter.on(`wat`, a => {
 		t.equal(a, `arg1`)
-		t.equal(b, `arg2`)
 		t.ok(firstFired)
 		t.end()
 	})
 
-	emitter.emit(`wat`, `arg1`, `arg2`)
+	emitter.emit(`wat`, `arg1`)
 })
 
 test(`Events fire synchronously`, t => {


### PR DESCRIPTION
Breaking changes!

- breaking: drop support for any number of event arguments.  I never used that feature anyway
- no more type assertions – extra code that hurts performance, but also they prevented you from using non-string event keys, which doesn't make sense

The second argument passed to listeners is an object with a `stopPropagation` property.