### PR TITLE
Clarify that the object passed into make_emitter isn't an emitter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ emitter.emit('thing happened', true, 'I dunno')
 unsubscribe()
 ```
 
-## `emitter = createEmitter([emitter])`
+## `emitter = createEmitter([obj])`
 
 This is the function exported by the module.  It creates a new event emitter object.  You can also pass in any object you want, and event emitter functions will be added to it.
 


### PR DESCRIPTION
The way the readme code is written now, it kinda looks like you're supposed to pass an emitter into `createEmitter`, which is not how it works.